### PR TITLE
Добавлена поддержка SOCKS5-прокси для Spotify

### DIFF
--- a/app/core/factory.py
+++ b/app/core/factory.py
@@ -8,6 +8,7 @@ from app.adapters.store_providers import STORE_REGISTRY
 from app.core.interfaces import StoreProvider
 from app.core.models import StoreType
 from app.core.service import DownloadService
+from app.infra.app_config import init_app_config
 from app.infra.logging import configure_logging
 from app.infra.settings import Settings
 from app.infra.storage import StorageManager
@@ -18,6 +19,7 @@ def create_service(settings: Settings) -> DownloadService:
 
     configure_logging(settings.log_level)
     storage = StorageManager(settings.download_dir, settings.config_dir, settings.default_template)
+    config_repo = init_app_config(settings.config_dir)
     playlist_provider = SpotifyPlaylistProvider(batch_delay=settings.spotify_batch_delay)
 
     store_providers: Dict[StoreType, StoreProvider] = {}
@@ -32,5 +34,6 @@ def create_service(settings: Settings) -> DownloadService:
         playlist_provider=playlist_provider,
         store_providers=store_providers,
         storage=storage,
+        config_repo=config_repo,
         worker_concurrency=settings.worker_concurrency,
     )

--- a/app/infra/app_config.py
+++ b/app/infra/app_config.py
@@ -1,0 +1,167 @@
+"""Хранение и валидация пользовательских настроек приложения."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from threading import RLock
+from typing import Any, Dict, Optional
+
+from app.infra.settings import Settings
+
+
+@dataclass
+class ProxySettings:
+    """Параметры SOCKS5-прокси для Spotify."""
+
+    enabled: bool = False
+    host: str = ""
+    port: int = 0
+    username: str = ""
+    password: str = ""
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, Any]) -> "ProxySettings":
+        """Создаёт объект из словаря."""
+
+        return cls(
+            enabled=bool(payload.get("enabled", False)),
+            host=str(payload.get("host", "") or ""),
+            port=int(payload.get("port") or 0),
+            username=str(payload.get("username", "") or ""),
+            password=str(payload.get("password", "") or ""),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Преобразует объект в сериализуемый словарь."""
+
+        return {
+            "enabled": self.enabled,
+            "host": self.host,
+            "port": self.port or None,
+            "username": self.username,
+            "password": self.password,
+        }
+
+    def as_requests_proxies(self) -> Optional[Dict[str, str]]:
+        """Возвращает словарь для requests, если прокси настроен."""
+
+        if not self.enabled:
+            return None
+        if not self.host or not self.port:
+            return None
+        credentials = ""
+        if self.username:
+            credentials = self.username
+            if self.password:
+                credentials += f":{self.password}"
+            credentials += "@"
+        address = f"socks5h://{credentials}{self.host}:{self.port}"
+        return {"http": address, "https": address}
+
+
+@dataclass
+class AppSettings:
+    """Контейнер пользовательских настроек приложения."""
+
+    proxy: ProxySettings = field(default_factory=ProxySettings)
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, Any]) -> "AppSettings":
+        """Создаёт объект из словаря."""
+
+        proxy_payload = payload.get("proxy", {}) if isinstance(payload, dict) else {}
+        return cls(proxy=ProxySettings.from_dict(proxy_payload))
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Преобразует настройки в словарь."""
+
+        return {"proxy": self.proxy.to_dict()}
+
+
+class AppConfigRepository:
+    """Менеджер чтения и записи настроек на диске."""
+
+    def __init__(self, config_dir: Path) -> None:
+        self._config_path = config_dir / "app-settings.json"
+        self._lock = RLock()
+        self._cached: Optional[AppSettings] = None
+
+    @property
+    def config_path(self) -> Path:
+        """Полный путь к файлу с настройками."""
+
+        return self._config_path
+
+    def _ensure_loaded(self) -> AppSettings:
+        if self._cached is not None:
+            return self._cached
+        if not self._config_path.exists():
+            self._cached = AppSettings()
+            return self._cached
+        try:
+            data = json.loads(self._config_path.read_text())
+        except (OSError, ValueError):
+            self._cached = AppSettings()
+        else:
+            self._cached = AppSettings.from_dict(data)
+        return self._cached
+
+    def load(self) -> AppSettings:
+        """Возвращает настройки, кэшируя результат."""
+
+        with self._lock:
+            return self._ensure_loaded()
+
+    def _write(self, settings: AppSettings) -> AppSettings:
+        self._config_path.parent.mkdir(parents=True, exist_ok=True)
+        self._config_path.write_text(
+            json.dumps(settings.to_dict(), ensure_ascii=False, indent=2)
+        )
+        self._cached = settings
+        return settings
+
+    def save(self, settings: AppSettings) -> AppSettings:
+        """Сохраняет переданные настройки на диск."""
+
+        with self._lock:
+            return self._write(settings)
+
+    def update_proxy(self, proxy: ProxySettings) -> AppSettings:
+        """Обновляет только блок настроек прокси."""
+
+        with self._lock:
+            current = self._ensure_loaded()
+            current.proxy = proxy
+            return self._write(current)
+
+    def build_requests_proxies(self) -> Optional[Dict[str, str]]:
+        """Подготавливает параметры прокси для requests."""
+
+        with self._lock:
+            settings = self._ensure_loaded()
+            return settings.proxy.as_requests_proxies()
+
+
+_repo_lock = RLock()
+_active_repo: Optional[AppConfigRepository] = None
+
+
+def init_app_config(config_dir: Path) -> AppConfigRepository:
+    """Создаёт и запоминает репозиторий настроек для указанной папки."""
+
+    global _active_repo
+    with _repo_lock:
+        _active_repo = AppConfigRepository(config_dir)
+        return _active_repo
+
+
+def get_app_config() -> AppConfigRepository:
+    """Возвращает активный репозиторий настроек."""
+
+    global _active_repo
+    with _repo_lock:
+        if _active_repo is None:
+            settings = Settings()
+            _active_repo = AppConfigRepository(settings.config_dir)
+        return _active_repo

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -2,6 +2,7 @@ fastapi==0.111.0
 uvicorn[standard]==0.29.0
 typer==0.12.3
 requests==2.31.0
+PySocks==1.7.1
 mutagen==1.47.0
 pyotp==2.9.0
 pydantic==2.6.3

--- a/app/ui/src/api.ts
+++ b/app/ui/src/api.ts
@@ -1,4 +1,4 @@
-import { FilesResponse, JobModel, JobResponse, JobsListResponse, ProvidersResponse } from "./types";
+import type { AppSettings, FilesResponse, JobModel, JobResponse, JobsListResponse, ProvidersResponse } from "./types";
 
 const API_BASE = (import.meta.env.VITE_API_BASE as string | undefined) ?? "/api";
 
@@ -51,6 +51,10 @@ export async function fetchFiles(): Promise<FilesResponse> {
   return request<FilesResponse>("/files");
 }
 
+export async function fetchSettings(): Promise<AppSettings> {
+  return request<AppSettings>("/settings");
+}
+
 export async function createJob(body: {
   provider: string;
   store: string;
@@ -74,6 +78,13 @@ export async function saveTokens(provider: string, data: Record<string, unknown>
 export async function fetchJobLogs(jobId: string): Promise<string[]> {
   const response = await request<{ logs: string[] }>(`/jobs/${jobId}/logs`);
   return response.logs;
+}
+
+export async function updateSettings(body: AppSettings): Promise<AppSettings> {
+  return request<AppSettings>("/settings", {
+    method: "PUT",
+    body: JSON.stringify(body)
+  });
 }
 
 export function subscribeProgress(onUpdate: (job: JobModel) => void): () => void {

--- a/app/ui/src/main.css
+++ b/app/ui/src/main.css
@@ -50,7 +50,7 @@ label {
   color: #94a3b8;
 }
 
-input,
+input:not([type="checkbox"]),
 select,
 textarea {
   width: 100%;
@@ -63,7 +63,7 @@ textarea {
   transition: border 0.2s ease;
 }
 
-input:focus,
+input:not([type="checkbox"]):focus,
 select:focus,
 textarea:focus {
   outline: none;
@@ -93,10 +93,30 @@ button:disabled {
   box-shadow: none;
 }
 
+input[type="checkbox"] {
+  width: auto;
+  height: auto;
+  cursor: pointer;
+  accent-color: #38bdf8;
+}
+
 .form-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 1rem;
+}
+
+.checkbox-field {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-bottom: 1rem;
+}
+
+.checkbox-field label {
+  margin: 0;
+  color: #e2e8f0;
+  font-weight: 500;
 }
 
 .alert {

--- a/app/ui/src/types.ts
+++ b/app/ui/src/types.ts
@@ -3,6 +3,18 @@ export interface ProvidersResponse {
   stores: string[];
 }
 
+export interface ProxySettings {
+  enabled: boolean;
+  host: string;
+  port: number | null;
+  username: string;
+  password: string;
+}
+
+export interface AppSettings {
+  proxy: ProxySettings;
+}
+
 export interface JobModel {
   id: string;
   provider: string;

--- a/tests/core/test_service.py
+++ b/tests/core/test_service.py
@@ -17,6 +17,7 @@ from app.core.models import (
     TrackMetadata,
 )
 from app.core.service import DownloadService, JobRequest
+from app.infra.app_config import AppConfigRepository, ProxySettings
 from app.infra.storage import StorageManager
 
 
@@ -148,6 +149,7 @@ async def test_успешная_загрузка(настройки: StorageMana
         плейлист,
         {StoreType.QOBUZ: магазин},
         настройки,
+        config_repo=AppConfigRepository(настройки.config_dir),
     )
 
     await сервис.start()
@@ -196,6 +198,7 @@ async def test_отмена_задачи(настройки: StorageManager) -> 
         плейлист,
         {StoreType.QOBUZ: магазин},
         настройки,
+        config_repo=AppConfigRepository(настройки.config_dir),
     )
 
     await сервис.start()
@@ -229,6 +232,7 @@ async def test_ошибка_провайдера_при_пустом_списк�
         плейлист,
         {StoreType.QOBUZ: магазин},
         настройки,
+        config_repo=AppConfigRepository(настройки.config_dir),
     )
 
     await сервис.start()
@@ -248,3 +252,37 @@ async def test_ошибка_провайдера_при_пустом_списк�
         assert финальный.total_tracks == 0
     finally:
         await сервис.stop()
+
+
+def test_настройки_прокси(настройки: StorageManager) -> None:
+    """Проверяет чтение и обновление настроек прокси."""
+
+    репозиторий = AppConfigRepository(настройки.config_dir)
+    сервис = DownloadService(
+        ЗаглушкаПлейлиста([]),
+        {},
+        настройки,
+        config_repo=репозиторий,
+    )
+
+    по_умолчанию = сервис.get_settings()
+    assert по_умолчанию["proxy"]["enabled"] is False
+    assert по_умолчанию["proxy"]["host"] == ""
+
+    обновлённые = сервис.update_settings(
+        ProxySettings(
+            enabled=True,
+            host="127.0.0.1",
+            port=1088,
+            username="user",
+            password="pass",
+        )
+    )
+
+    assert обновлённые["proxy"]["enabled"] is True
+    assert обновлённые["proxy"]["port"] == 1088
+    assert сервис.get_settings() == обновлённые
+    assert репозиторий.build_requests_proxies() == {
+        "http": "socks5h://user:pass@127.0.0.1:1088",
+        "https": "socks5h://user:pass@127.0.0.1:1088",
+    }


### PR DESCRIPTION
## Summary
- добавить репозиторий настроек и проксирование запросов Spotify через SOCKS5
- расширить API и веб-интерфейс возможностью управлять прокси
- обновить тесты и зависимости

## Testing
- pip install -r app/requirements-dev.txt
- pytest
- npm --prefix app/ui run build

------
https://chatgpt.com/codex/tasks/task_e_68d50401024c832a955310de6e284981