### PR TITLE
Добавить выбор структуры скачиваний и обновить интерфейс

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 * загрузка треков/альбомов/плейлистов Spotify через Qobuz, Tidal, Deezer и Amazon;
 * тегирование и переименование по шаблону `{artist}/{album}/{track:02d} - {title}.{ext}`;
 * хранение конфигурации и токенов в каталоге `/config`, файлов — в `/downloads`;
+* выбор структуры каталога загрузок: по артистам или в одну папку;
 * live-прогресс задач через WebSocket и обновляемый список файлов;
 * сборка через Docker/Docker Compose для API и UI.
 
@@ -59,6 +60,8 @@ python -m app.cli.main fetch \
 
 ## Веб-API
 
+Полное описание схем, запросов и форматов ответов доступно в [docs/API.md](docs/API.md).
+
 * `POST /auth/{provider}` — сохранить токены провайдера;
 * `GET /providers` — список доступных источников и магазинов;
 * `POST /jobs` — создать задачу (`provider`, `store`, `url`, опционально `quality`, `path_template`);
@@ -66,6 +69,7 @@ python -m app.cli.main fetch \
 * `DELETE /jobs/{id}` — отменить задачу;
 * `GET /jobs/{id}/logs` — последние записи лога;
 * `GET /files` — список выгруженных файлов;
+* `GET /settings` / `PUT /settings` — получить или обновить прокси и режим сохранения файлов;
 * `GET /healthz`, `/readyz`, `/metrics` — служебные эндпоинты;
 * `WS /ws/progress` — live-обновления задач.
 

--- a/app/cli/main.py
+++ b/app/cli/main.py
@@ -74,7 +74,7 @@ def fetch(
                 store=_parse_store(store),
                 url=url,
                 quality=quality,
-                path_template=path_template or settings.default_template,
+                path_template=path_template,
             )
             snapshot = await service.submit_job(request)
             return await _watch_job(service, snapshot.id)

--- a/app/core/factory.py
+++ b/app/core/factory.py
@@ -19,7 +19,7 @@ def create_service(settings: Settings) -> DownloadService:
 
     configure_logging(settings.log_level)
     storage = StorageManager(settings.download_dir, settings.config_dir, settings.default_template)
-    config_repo = init_app_config(settings.config_dir)
+    config_repo = init_app_config(settings.config_dir, settings=settings)
     playlist_provider = SpotifyPlaylistProvider(batch_delay=settings.spotify_batch_delay)
 
     store_providers: Dict[StoreType, StoreProvider] = {}

--- a/app/core/models.py
+++ b/app/core/models.py
@@ -23,6 +23,13 @@ class StoreType(str, Enum):
     AMAZON = "amazon"
 
 
+class DownloadMode(str, Enum):
+    """Варианты организации каталога загрузок."""
+
+    BY_ARTIST = "by_artist"
+    SINGLE_FOLDER = "single_folder"
+
+
 class JobStatus(str, Enum):
     """Состояние задачи загрузки."""
 

--- a/app/infra/settings.py
+++ b/app/infra/settings.py
@@ -14,6 +14,10 @@ class Settings:
         "PATH_TEMPLATE",
         "{artist}/{album}/{track:02d} - {title}.{ext}",
     )
+    flat_template: str = os.environ.get(
+        "PATH_TEMPLATE_FLAT",
+        "{artist} - {album} - {track:02d} - {title}.{ext}",
+    )
     worker_concurrency: int = int(os.environ.get("WORKER_CONCURRENCY", "1"))
     spotify_batch_delay: float = float(os.environ.get("SPOTIFY_BATCH_DELAY", "0.2"))
     log_level: str = os.environ.get("LOG_LEVEL", "INFO")

--- a/app/ui/src/App.tsx
+++ b/app/ui/src/App.tsx
@@ -9,7 +9,14 @@ import {
   subscribeProgress,
   updateSettings
 } from "./api";
-import type { AppSettings, FileItem, JobModel, ProvidersResponse } from "./types";
+import type {
+  AppSettings,
+  DownloadMode,
+  DownloadSettings,
+  FileItem,
+  JobModel,
+  ProvidersResponse
+} from "./types";
 
 interface FormState {
   url: string;
@@ -27,13 +34,24 @@ interface ProxyFormState {
   password: string;
 }
 
+const DEFAULT_BY_ARTIST_TEMPLATE = "{artist}/{album}/{track:02d} - {title}.{ext}";
+const DEFAULT_SINGLE_TEMPLATE = "{artist} - {album} - {track:02d} - {title}.{ext}";
+
 const STATUS_STYLE: Record<string, { label: string; color: string }> = {
-  pending: { label: "В очереди", color: "#fbbf24" },
-  running: { label: "В работе", color: "#38bdf8" },
+  pending: { label: "В очереди", color: "#60a5fa" },
+  running: { label: "В работе", color: "#22d3ee" },
   completed: { label: "Готово", color: "#34d399" },
   failed: { label: "Ошибка", color: "#f87171" },
   cancelled: { label: "Отменено", color: "#cbd5f5" }
 };
+
+function templateForMode(mode: DownloadMode, settings?: DownloadSettings | null): string {
+  const source = settings ?? null;
+  if (source) {
+    return mode === "single_folder" ? source.single_folder_template : source.by_artist_template;
+  }
+  return mode === "single_folder" ? DEFAULT_SINGLE_TEMPLATE : DEFAULT_BY_ARTIST_TEMPLATE;
+}
 
 function formatDate(date: string | null): string {
   if (!date) {
@@ -82,10 +100,14 @@ const App: React.FC = () => {
   const [files, setFiles] = useState<FileItem[]>([]);
   const [form, setForm] = useState<FormState>(DEFAULT_FORM);
   const [proxyForm, setProxyForm] = useState<ProxyFormState>(DEFAULT_PROXY_FORM);
+  const [downloadSettings, setDownloadSettings] = useState<DownloadSettings | null>(null);
+  const [autoTemplate, setAutoTemplate] = useState<string>(DEFAULT_BY_ARTIST_TEMPLATE);
+  const [pathTemplateEdited, setPathTemplateEdited] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [proxyBusy, setProxyBusy] = useState(false);
+  const [downloadBusy, setDownloadBusy] = useState(false);
   const [selectedJob, setSelectedJob] = useState<JobModel | null>(null);
   const [jobLogs, setJobLogs] = useState<string[]>([]);
   const [logsLoading, setLogsLoading] = useState(false);
@@ -119,6 +141,14 @@ const App: React.FC = () => {
     }
   }, []);
 
+  const applyTemplate = useCallback((template: string, force = false) => {
+    setAutoTemplate(template);
+    if (force || !pathTemplateEdited) {
+      setForm((prev) => ({ ...prev, pathTemplate: template }));
+      setPathTemplateEdited(false);
+    }
+  }, [pathTemplateEdited]);
+
   useEffect(() => {
     (async () => {
       try {
@@ -131,7 +161,13 @@ const App: React.FC = () => {
         setProviders(prov);
         setJobs(sortJobs(jobsResponse.jobs));
         setFiles(filesResponse.files);
-        setForm((prev) => ({ ...prev, store: prov.stores[0] ?? prev.store }));
+        setForm((prev) => ({
+          ...prev,
+          store: prov.stores[0] ?? prev.store,
+          pathTemplate: prev.pathTemplate || settingsResponse.download.active_template
+        }));
+        setAutoTemplate(settingsResponse.download.active_template);
+        setPathTemplateEdited(false);
         setProxyForm({
           enabled: settingsResponse.proxy.enabled,
           host: settingsResponse.proxy.host,
@@ -139,6 +175,7 @@ const App: React.FC = () => {
           username: settingsResponse.proxy.username,
           password: settingsResponse.proxy.password
         });
+        setDownloadSettings(settingsResponse.download);
       } catch (err) {
         console.error(err);
         setError((err as Error).message);
@@ -167,9 +204,11 @@ const App: React.FC = () => {
     return unsubscribe;
   }, [refreshFiles, updateJobList]);
 
-
   const handleChange = (field: keyof FormState) => (event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     const value = event.target.value;
+    if (field === "pathTemplate") {
+      setPathTemplateEdited(value !== autoTemplate);
+    }
     setForm((prev) => ({ ...prev, [field]: value }));
   };
 
@@ -182,6 +221,23 @@ const App: React.FC = () => {
     const checked = event.target.checked;
     setProxyForm((prev) => ({ ...prev, enabled: checked }));
   };
+
+  const buildDownloadPayload = useCallback(
+    (source?: DownloadSettings | null): DownloadSettings => {
+      const base = source ?? downloadSettings ?? {
+        mode: "by_artist",
+        active_template: DEFAULT_BY_ARTIST_TEMPLATE,
+        by_artist_template: DEFAULT_BY_ARTIST_TEMPLATE,
+        single_folder_template: DEFAULT_SINGLE_TEMPLATE
+      };
+      const active = templateForMode(base.mode, base);
+      return {
+        ...base,
+        active_template: active
+      };
+    },
+    [downloadSettings]
+  );
 
   const handleSaveProxy = async (event: React.FormEvent) => {
     event.preventDefault();
@@ -217,7 +273,8 @@ const App: React.FC = () => {
           port: parsedPort,
           username: proxyForm.username,
           password: proxyForm.password
-        }
+        },
+        download: buildDownloadPayload()
       };
       const saved = await updateSettings(payload);
       setProxyForm({
@@ -227,12 +284,81 @@ const App: React.FC = () => {
         username: saved.proxy.username,
         password: saved.proxy.password
       });
+      setDownloadSettings(saved.download);
+      applyTemplate(saved.download.active_template, true);
       setMessage("Настройки сохранены");
     } catch (err) {
       setError((err as Error).message);
     } finally {
       setProxyBusy(false);
     }
+  };
+
+  const handleSaveDownload = async () => {
+    if (!downloadSettings) {
+      setError("Настройки ещё загружаются, повторите позже");
+      return;
+    }
+    const trimmedPort = proxyForm.port.trim();
+    if (trimmedPort && Number.isNaN(Number(trimmedPort))) {
+      setError("Порт должен быть числом");
+      return;
+    }
+    const parsedPort = trimmedPort ? Number(trimmedPort) : null;
+    setDownloadBusy(true);
+    setError(null);
+    try {
+      const payload: AppSettings = {
+        proxy: {
+          enabled: proxyForm.enabled,
+          host: proxyForm.host.trim(),
+          port: parsedPort,
+          username: proxyForm.username,
+          password: proxyForm.password
+        },
+        download: buildDownloadPayload(downloadSettings)
+      };
+      const saved = await updateSettings(payload);
+      setDownloadSettings(saved.download);
+      applyTemplate(saved.download.active_template, true);
+      setMessage("Настройки сохранены");
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setDownloadBusy(false);
+    }
+  };
+
+  const handleDownloadModeChange = (mode: DownloadMode) => {
+    setDownloadSettings((prev) => {
+      const next: DownloadSettings = prev
+        ? {
+            ...prev,
+            mode,
+            active_template: templateForMode(mode, prev)
+          }
+        : {
+            mode,
+            active_template: templateForMode(mode),
+            by_artist_template: DEFAULT_BY_ARTIST_TEMPLATE,
+            single_folder_template: DEFAULT_SINGLE_TEMPLATE
+          };
+      setAutoTemplate(next.active_template);
+      if (!pathTemplateEdited) {
+        setForm((prevForm) => ({ ...prevForm, pathTemplate: next.active_template }));
+      }
+      return next;
+    });
+  };
+
+  const handleResetTemplate = () => {
+    setDownloadSettings((prev) => {
+      const next = buildDownloadPayload(prev);
+      setAutoTemplate(next.active_template);
+      setForm((prevForm) => ({ ...prevForm, pathTemplate: next.active_template }));
+      setPathTemplateEdited(false);
+      return next;
+    });
   };
 
   const handleCreateJob = async (event: React.FormEvent) => {
@@ -261,7 +387,6 @@ const App: React.FC = () => {
     }
   };
 
-
   const handleSelectJob = async (job: JobModel) => {
     setSelectedJob(job);
     setJobLogs(job.logs);
@@ -280,230 +405,284 @@ const App: React.FC = () => {
   const statusColor = (status: string) => STATUS_STYLE[status]?.color ?? "#cbd5f5";
 
   return (
-    <main>
-      <header>
-        <h1>SpotiFLAC Control Center</h1>
-        <p style={{ color: "#94a3b8" }}>Очередь загрузок, токены и файлы в одном месте.</p>
+    <main className="app-shell">
+      <header className="app-header">
+        <div>
+          <h1>SpotiFLAC Control Center</h1>
+          <p className="muted">Управляйте загрузками, сетевыми настройками и структурой файлов из одного окна.</p>
+        </div>
+        <div className="header-actions">
+          <span className="chip">API v1</span>
+        </div>
       </header>
 
-      {message && (
-        <div className="alert">
-          {message}
-        </div>
-      )}
-      {error && (
-        <div className="alert error">
-          {error}
-        </div>
-      )}
+      {message && <div className="alert success">{message}</div>}
+      {error && <div className="alert error">{error}</div>}
 
-      <section>
-        <header>
-          <h2>Сетевые настройки</h2>
-          <span style={{ color: "#64748b" }}>SOCKS5-прокси для запросов к Spotify</span>
-        </header>
-        <form onSubmit={handleSaveProxy}>
-          <div className="checkbox-field">
-            <input
-              id="proxy-enabled"
-              type="checkbox"
-              checked={proxyForm.enabled}
-              onChange={handleProxyToggle}
-            />
-            <label htmlFor="proxy-enabled">Использовать прокси</label>
-          </div>
-          <div className="form-grid">
+      <div className="grid grid--two">
+        <section className="panel">
+          <div className="panel-header">
             <div>
-              <label htmlFor="proxy-host">Адрес</label>
-              <input
-                id="proxy-host"
-                placeholder="127.0.0.1"
-                value={proxyForm.host}
-                onChange={handleProxyField("host")}
-              />
-            </div>
-            <div>
-              <label htmlFor="proxy-port">Порт</label>
-              <input
-                id="proxy-port"
-                placeholder="1080"
-                value={proxyForm.port}
-                inputMode="numeric"
-                onChange={handleProxyField("port")}
-              />
-            </div>
-            <div>
-              <label htmlFor="proxy-username">Логин</label>
-              <input
-                id="proxy-username"
-                placeholder="Необязательно"
-                value={proxyForm.username}
-                onChange={handleProxyField("username")}
-                autoComplete="username"
-              />
-            </div>
-            <div>
-              <label htmlFor="proxy-password">Пароль</label>
-              <input
-                id="proxy-password"
-                type="password"
-                placeholder="Необязательно"
-                value={proxyForm.password}
-                onChange={handleProxyField("password")}
-                autoComplete="current-password"
-              />
+              <h2>Сетевые настройки</h2>
+              <p className="muted">SOCKS5-прокси для обращения к Spotify</p>
             </div>
           </div>
-          <div style={{ marginTop: "1rem", display: "flex", justifyContent: "flex-end" }}>
-            <button type="submit" disabled={proxyBusy}>
-              {proxyBusy ? "Сохранение..." : "Сохранить"}
+          <form onSubmit={handleSaveProxy} className="panel-form">
+            <div className="toggle-line">
+              <label className="switch">
+                <input
+                  id="proxy-enabled"
+                  type="checkbox"
+                  checked={proxyForm.enabled}
+                  onChange={handleProxyToggle}
+                />
+                <span>Использовать прокси</span>
+              </label>
+            </div>
+            <div className="form-grid">
+              <div>
+                <label htmlFor="proxy-host">Адрес</label>
+                <input
+                  id="proxy-host"
+                  placeholder="127.0.0.1"
+                  value={proxyForm.host}
+                  onChange={handleProxyField("host")}
+                />
+              </div>
+              <div>
+                <label htmlFor="proxy-port">Порт</label>
+                <input
+                  id="proxy-port"
+                  placeholder="1080"
+                  value={proxyForm.port}
+                  inputMode="numeric"
+                  onChange={handleProxyField("port")}
+                />
+              </div>
+              <div>
+                <label htmlFor="proxy-username">Логин</label>
+                <input
+                  id="proxy-username"
+                  placeholder="Необязательно"
+                  value={proxyForm.username}
+                  onChange={handleProxyField("username")}
+                  autoComplete="username"
+                />
+              </div>
+              <div>
+                <label htmlFor="proxy-password">Пароль</label>
+                <input
+                  id="proxy-password"
+                  type="password"
+                  placeholder="Необязательно"
+                  value={proxyForm.password}
+                  onChange={handleProxyField("password")}
+                  autoComplete="current-password"
+                />
+              </div>
+            </div>
+            <div className="panel-actions">
+              <button type="submit" disabled={proxyBusy}>
+                {proxyBusy ? "Сохранение..." : "Сохранить"}
+              </button>
+            </div>
+          </form>
+        </section>
+
+        <section className="panel panel--highlight">
+          <div className="panel-header">
+            <div>
+              <h2>Структура файлов</h2>
+              <p className="muted">Выберите, как организовать загруженные треки</p>
+            </div>
+          </div>
+          <div className="segmented">
+            <button
+              type="button"
+              className={downloadSettings?.mode === "by_artist" ? "active" : ""}
+              onClick={() => handleDownloadModeChange("by_artist")}
+            >
+              По артистам
+            </button>
+            <button
+              type="button"
+              className={downloadSettings?.mode === "single_folder" ? "active" : ""}
+              onClick={() => handleDownloadModeChange("single_folder")}
+            >
+              В одну папку
             </button>
           </div>
-        </form>
-      </section>
-
-      <section>
-        <header>
-          <h2>Новая задача</h2>
-          <span style={{ color: "#64748b" }}>Создайте загрузку из Spotify-ссылки</span>
-        </header>
-        <form onSubmit={handleCreateJob}>
-          <div className="form-grid">
-            <div>
-              <label htmlFor="url">Spotify URL</label>
-              <input
-                id="url"
-                placeholder="https://open.spotify.com/..."
-                value={form.url}
-                onChange={handleChange("url")}
-              />
-            </div>
-            <div>
-              <label htmlFor="store">Магазин загрузки</label>
-              <select id="store" value={form.store} onChange={handleChange("store")}>
-                {(providers?.stores ?? []).map((storeOption) => (
-                  <option key={storeOption} value={storeOption}>
-                    {storeOption}
-                  </option>
-                ))}
-              </select>
-            </div>
-            <div>
-              <label htmlFor="quality">Качество</label>
-              <input
-                id="quality"
-                placeholder="LOSSLESS / 24-bit / ..."
-                value={form.quality}
-                onChange={handleChange("quality")}
-              />
-            </div>
-            <div>
-              <label htmlFor="template">Шаблон пути</label>
-              <input
-                id="template"
-                placeholder="{artist}/{album}/{track:02d} - {title}.{ext}"
-                value={form.pathTemplate}
-                onChange={handleChange("pathTemplate")}
-              />
-            </div>
+          <div className="template-preview">
+            <span className="muted">Текущий шаблон</span>
+            <code>{downloadSettings?.active_template ?? autoTemplate}</code>
+            <p className="muted">Шаблон применяется ко всем новым задачам. Вы можете вручную переопределить путь при создании загрузки.</p>
           </div>
-          <div style={{ marginTop: "1rem", display: "flex", justifyContent: "flex-end" }}>
-            <button type="submit" disabled={busy}>
-              {busy ? "Создание..." : "Создать задачу"}
+          <div className="panel-actions">
+            <button type="button" className="ghost-button" onClick={handleResetTemplate}>
+              Сбросить шаблон
+            </button>
+            <button type="button" onClick={handleSaveDownload} disabled={downloadBusy}>
+              {downloadBusy ? "Сохранение..." : "Сохранить режим"}
             </button>
           </div>
-        </form>
-      </section>
+        </section>
+      </div>
 
+      <div className="grid grid--two">
+        <section className="panel">
+          <div className="panel-header">
+            <div>
+              <h2>Новая задача</h2>
+              <p className="muted">Создайте загрузку из ссылки Spotify</p>
+            </div>
+          </div>
+          <form onSubmit={handleCreateJob} className="panel-form">
+            <div className="form-grid">
+              <div className="span-2">
+                <label htmlFor="url">Spotify URL</label>
+                <input
+                  id="url"
+                  placeholder="https://open.spotify.com/..."
+                  value={form.url}
+                  onChange={handleChange("url")}
+                />
+              </div>
+              <div>
+                <label htmlFor="store">Магазин загрузки</label>
+                <select id="store" value={form.store} onChange={handleChange("store") }>
+                  {(providers?.stores ?? []).map((storeOption) => (
+                    <option key={storeOption} value={storeOption}>
+                      {storeOption}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label htmlFor="quality">Качество</label>
+                <input
+                  id="quality"
+                  placeholder="LOSSLESS / 24-bit / ..."
+                  value={form.quality}
+                  onChange={handleChange("quality")}
+                />
+              </div>
+              <div className="span-2">
+                <label htmlFor="template">Шаблон пути</label>
+                <input
+                  id="template"
+                  placeholder="{artist}/{album}/{track:02d} - {title}.{ext}"
+                  value={form.pathTemplate}
+                  onChange={handleChange("pathTemplate")}
+                />
+                <p className="hint muted">Необязательно. Если оставить пустым, будет использован выбранный выше режим.</p>
+              </div>
+            </div>
+            <div className="panel-actions">
+              <button type="submit" disabled={busy}>
+                {busy ? "Создание..." : "Создать задачу"}
+              </button>
+            </div>
+          </form>
+        </section>
 
-      <section>
-        <header>
-          <h2>Очередь</h2>
-          <button type="button" onClick={refreshJobs} style={{ background: "transparent", color: "#38bdf8" }}>
-            Обновить
-          </button>
-        </header>
-        <div style={{ overflowX: "auto" }}>
-          <table className="table">
-            <thead>
-              <tr>
-                <th>ID</th>
-                <th>Статус</th>
-                <th>Прогресс</th>
-                <th>Треки</th>
-                <th>Магазин</th>
-                <th>Создана</th>
-                <th>Сообщение</th>
-              </tr>
-            </thead>
-            <tbody>
-              {jobs.map((job) => (
-                <tr key={job.id} onClick={() => handleSelectJob(job)}>
-                  <td style={{ fontFamily: "JetBrains Mono, monospace" }}>{job.id.slice(0, 8)}</td>
-                  <td>
-                    <span className="status-badge" style={{ background: `${statusColor(job.status)}33`, color: statusColor(job.status) }}>
-                      {statusLabel(job.status)}
-                    </span>
-                  </td>
-                  <td style={{ width: "160px" }}>
-                    <div className="progress-bar">
-                      <span style={{ width: `${Math.round(job.progress * 100)}%` }} />
-                    </div>
-                  </td>
-                  <td>
-                    {job.completed_tracks}/{job.total_tracks}
-                  </td>
-                  <td>{job.store}</td>
-                  <td>{formatDate(job.created_at)}</td>
-                  <td>{job.message ?? job.error ?? ""}</td>
-                </tr>
-              ))}
-              {jobs.length === 0 && (
+        <section className="panel">
+          <div className="panel-header">
+            <div>
+              <h2>Недавние файлы</h2>
+              <p className="muted">Последние результаты из каталога /downloads</p>
+            </div>
+          </div>
+          <div className="files-list">
+            {files.map((file) => (
+              <div className="file-card" key={file.path}>
+                <strong>{file.path}</strong>
+                <span>{humanSize(file.size)} · {formatDate(file.modified_at)}</span>
+              </div>
+            ))}
+            {files.length === 0 && <p className="muted">Файлы ещё не загружены.</p>}
+          </div>
+        </section>
+      </div>
+
+      <div className="grid grid--main">
+        <section className="panel">
+          <div className="panel-header">
+            <div>
+              <h2>Очередь</h2>
+              <p className="muted">Активные и завершённые задачи</p>
+            </div>
+            <button type="button" className="ghost-button" onClick={refreshJobs}>
+              Обновить
+            </button>
+          </div>
+          <div className="table-wrapper">
+            <table className="table">
+              <thead>
                 <tr>
-                  <td colSpan={7} style={{ textAlign: "center", padding: "1.5rem", color: "#64748b" }}>
-                    Пока нет задач
-                  </td>
+                  <th>ID</th>
+                  <th>Статус</th>
+                  <th>Прогресс</th>
+                  <th>Треки</th>
+                  <th>Магазин</th>
+                  <th>Создана</th>
+                  <th>Сообщение</th>
                 </tr>
-              )}
-            </tbody>
-          </table>
-        </div>
-      </section>
+              </thead>
+              <tbody>
+                {jobs.map((job) => (
+                  <tr key={job.id} onClick={() => handleSelectJob(job)}>
+                    <td className="mono">{job.id.slice(0, 8)}</td>
+                    <td>
+                      <span className="status-badge" style={{ color: statusColor(job.status) }}>
+                        <span className="dot" style={{ background: statusColor(job.status) }} />
+                        {statusLabel(job.status)}
+                      </span>
+                    </td>
+                    <td>
+                      <div className="progress-bar">
+                        <span style={{ width: `${Math.round(job.progress * 100)}%` }} />
+                      </div>
+                    </td>
+                    <td>{job.completed_tracks}/{job.total_tracks}</td>
+                    <td>{job.store}</td>
+                    <td>{formatDate(job.created_at)}</td>
+                    <td>{job.message ?? job.error ?? ""}</td>
+                  </tr>
+                ))}
+                {jobs.length === 0 && (
+                  <tr>
+                    <td colSpan={7} className="empty-cell">Пока нет задач</td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
 
-      {selectedJob && (
-        <section>
-          <header>
-            <h2>Логи задачи {selectedJob.id.slice(0, 8)}</h2>
-            <span style={{ color: statusColor(selectedJob.status) }}>{statusLabel(selectedJob.status)}</span>
-          </header>
+        <section className="panel">
+          <div className="panel-header">
+            <div>
+              <h2>Логи</h2>
+              <p className="muted">Выберите задачу, чтобы увидеть историю событий</p>
+            </div>
+            {selectedJob && (
+              <span className="status-badge" style={{ color: statusColor(selectedJob.status) }}>
+                <span className="dot" style={{ background: statusColor(selectedJob.status) }} />
+                {statusLabel(selectedJob.status)}
+              </span>
+            )}
+          </div>
           <div className="logs-box">
             {logsLoading && <p>Загрузка логов...</p>}
-            {!logsLoading && jobLogs.length === 0 && <p>Логи отсутствуют.</p>}
+            {!logsLoading && selectedJob === null && <p className="muted">Выберите задачу в таблице.</p>}
+            {!logsLoading && selectedJob !== null && jobLogs.length === 0 && <p className="muted">Логи отсутствуют.</p>}
             {!logsLoading &&
               jobLogs.map((line, index) => (
                 <p key={`${line}-${index}`}>{line}</p>
               ))}
           </div>
         </section>
-      )}
-
-      <section>
-        <header>
-          <h2>Недавние файлы</h2>
-          <span style={{ color: "#64748b" }}>Последние загрузки из каталога /downloads</span>
-        </header>
-        <div className="files-list">
-          {files.map((file) => (
-            <div className="file-card" key={file.path}>
-              <strong>{file.path}</strong>
-              <div style={{ color: "#94a3b8", fontSize: "0.85rem", marginTop: "0.35rem" }}>
-                {humanSize(file.size)} • {formatDate(file.modified_at)}
-              </div>
-            </div>
-          ))}
-          {files.length === 0 && <p style={{ color: "#64748b" }}>Файлы ещё не загружены.</p>}
-        </div>
-      </section>
+      </div>
     </main>
   );
 };

--- a/app/ui/src/main.css
+++ b/app/ui/src/main.css
@@ -1,66 +1,155 @@
 :root {
   color-scheme: dark;
   font-family: "Inter", "Segoe UI", sans-serif;
-  background: #0f172a;
+  background: #0a1022;
   color: #e2e8f0;
 }
 
 body {
   margin: 0;
   min-height: 100vh;
-  background: linear-gradient(180deg, #0b1220 0%, #111c37 100%);
+  background: radial-gradient(circle at top, rgba(56, 189, 248, 0.12), transparent 45%),
+    radial-gradient(circle at bottom, rgba(103, 232, 249, 0.12), transparent 40%),
+    #060916;
 }
 
 a {
   color: inherit;
 }
 
-main {
+main,
+.app-shell {
   max-width: 1200px;
   margin: 0 auto;
   padding: 2rem 1.5rem 4rem;
 }
 
-h1 {
-  font-size: 2rem;
-  font-weight: 700;
-  margin-bottom: 1rem;
-}
-
-section {
-  background: rgba(15, 23, 42, 0.85);
-  border-radius: 16px;
-  padding: 1.5rem;
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
   margin-bottom: 1.5rem;
-  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.45);
-  backdrop-filter: blur(12px);
 }
 
-section header {
+.app-header h1 {
+  font-size: 2.1rem;
+  font-weight: 700;
+  margin: 0 0 0.5rem;
+}
+
+.muted {
+  color: #94a3b8;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.header-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.25);
+  color: #bfdbfe;
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+}
+
+.grid {
+  display: grid;
+  gap: 1.25rem;
+  margin-bottom: 1.5rem;
+}
+
+.grid--two {
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  align-items: stretch;
+}
+
+.grid--main {
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+}
+
+.panel {
+  background: rgba(12, 19, 38, 0.88);
+  border-radius: 20px;
+  padding: 1.5rem;
+  box-shadow: 0 18px 45px rgba(10, 15, 30, 0.5);
+  backdrop-filter: blur(18px);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.panel--highlight {
+  background: linear-gradient(160deg, rgba(15, 118, 110, 0.25), rgba(15, 23, 42, 0.75));
+  border: 1px solid rgba(45, 212, 191, 0.25);
+}
+
+.panel-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1rem;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.panel-header h2 {
+  margin: 0 0 0.35rem;
+  font-size: 1.25rem;
+}
+
+.panel-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.toggle-line {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  cursor: pointer;
+  font-weight: 500;
+  color: #e2e8f0;
+}
+
+.switch input {
+  width: 20px;
+  height: 20px;
+  accent-color: #38bdf8;
 }
 
 label {
   display: block;
-  font-size: 0.9rem;
-  margin-bottom: 0.35rem;
-  color: #94a3b8;
+  font-size: 0.85rem;
+  margin-bottom: 0.4rem;
+  color: #a5b4fc;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 input:not([type="checkbox"]),
 select,
 textarea {
   width: 100%;
-  padding: 0.65rem 0.75rem;
-  border-radius: 10px;
-  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 0.6rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
   background: rgba(15, 23, 42, 0.6);
   color: #e2e8f0;
   font-size: 0.95rem;
-  transition: border 0.2s ease;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
 }
 
 input:not([type="checkbox"]):focus,
@@ -68,11 +157,27 @@ select:focus,
 textarea:focus {
   outline: none;
   border-color: #38bdf8;
-  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.3);
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.35);
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.form-grid .span-2 {
+  grid-column: span 2;
+}
+
+@media (max-width: 720px) {
+  .form-grid .span-2 {
+    grid-column: auto;
+  }
 }
 
 button {
-  padding: 0.65rem 1.4rem;
+  padding: 0.6rem 1.4rem;
   border-radius: 999px;
   border: none;
   background: linear-gradient(135deg, #22d3ee, #3b82f6);
@@ -82,9 +187,9 @@ button {
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-button:hover {
+button:hover:not(:disabled) {
   transform: translateY(-1px);
-  box-shadow: 0 15px 30px rgba(37, 99, 235, 0.35);
+  box-shadow: 0 18px 40px rgba(37, 99, 235, 0.35);
 }
 
 button:disabled {
@@ -93,70 +198,162 @@ button:disabled {
   box-shadow: none;
 }
 
-input[type="checkbox"] {
-  width: auto;
-  height: auto;
-  cursor: pointer;
-  accent-color: #38bdf8;
+.ghost-button {
+  background: rgba(59, 130, 246, 0.12);
+  color: #bfdbfe;
+  box-shadow: none;
 }
 
-.form-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1rem;
+.ghost-button:hover:not(:disabled) {
+  background: rgba(59, 130, 246, 0.2);
 }
 
-.checkbox-field {
+.panel-actions {
   display: flex;
-  align-items: center;
-  gap: 0.6rem;
-  margin-bottom: 1rem;
-}
-
-.checkbox-field label {
-  margin: 0;
-  color: #e2e8f0;
-  font-weight: 500;
+  justify-content: flex-end;
+  gap: 0.75rem;
 }
 
 .alert {
   padding: 0.75rem 1rem;
-  border-radius: 12px;
+  border-radius: 16px;
   margin-bottom: 1rem;
-  background: rgba(59, 130, 246, 0.18);
   border: 1px solid rgba(59, 130, 246, 0.35);
+  background: rgba(59, 130, 246, 0.15);
+}
+
+.alert.success {
+  border-color: rgba(45, 212, 191, 0.35);
+  background: rgba(45, 212, 191, 0.15);
 }
 
 .alert.error {
-  background: rgba(248, 113, 113, 0.18);
   border-color: rgba(248, 113, 113, 0.45);
+  background: rgba(248, 113, 113, 0.18);
+}
+
+.segmented {
+  display: inline-flex;
+  padding: 0.25rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  margin-bottom: 1rem;
+}
+
+.segmented button {
+  background: transparent;
+  color: #cbd5f5;
+  padding: 0.45rem 1rem;
+  border-radius: 999px;
+  border: none;
+  box-shadow: none;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.segmented button.active {
+  background: linear-gradient(135deg, rgba(34, 211, 238, 0.8), rgba(59, 130, 246, 0.9));
+  color: #0f172a;
+}
+
+.template-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1.2rem;
+  padding: 1rem;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.template-preview code {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.9rem;
+  color: #f8fafc;
+}
+
+.hint {
+  margin-top: 0.4rem;
+  font-size: 0.8rem;
+}
+
+.files-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.file-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.9rem 1rem;
+  border-radius: 14px;
+  background: rgba(30, 41, 59, 0.78);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.file-card strong {
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.file-card span {
+  font-size: 0.85rem;
+  color: #94a3b8;
+}
+
+.table-wrapper {
+  overflow-x: auto;
 }
 
 .table {
   width: 100%;
   border-collapse: collapse;
+  font-size: 0.9rem;
 }
 
 .table th,
 .table td {
-  padding: 0.75rem;
+  padding: 0.7rem 0.6rem;
   text-align: left;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.table tbody tr {
+  transition: background 0.15s ease, transform 0.15s ease;
+  cursor: pointer;
 }
 
 .table tbody tr:hover {
-  background: rgba(30, 41, 59, 0.6);
-  cursor: pointer;
+  background: rgba(59, 130, 246, 0.08);
+  transform: translateY(-1px);
+}
+
+.empty-cell {
+  text-align: center;
+  padding: 1.5rem;
+  color: #64748b;
 }
 
 .status-badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
-  padding: 0.3rem 0.7rem;
+  gap: 0.45rem;
+  padding: 0.35rem 0.8rem;
   border-radius: 999px;
   font-size: 0.8rem;
   font-weight: 600;
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.status-badge .dot {
+  display: inline-flex;
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
 }
 
 .progress-bar {
@@ -174,25 +371,12 @@ input[type="checkbox"] {
   transition: width 0.3s ease;
 }
 
-.files-list {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 0.75rem;
-}
-
-.file-card {
-  padding: 0.85rem;
-  border-radius: 12px;
-  background: rgba(30, 41, 59, 0.8);
-  border: 1px solid rgba(148, 163, 184, 0.12);
-}
-
 .logs-box {
-  max-height: 240px;
+  max-height: 260px;
   overflow-y: auto;
   padding: 1rem;
-  border-radius: 12px;
-  background: rgba(15, 23, 42, 0.7);
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.6);
   border: 1px solid rgba(148, 163, 184, 0.15);
   font-family: "JetBrains Mono", "Fira Code", monospace;
   font-size: 0.85rem;
@@ -204,12 +388,29 @@ input[type="checkbox"] {
   color: #cbd5f5;
 }
 
-@media (max-width: 720px) {
-  main {
-    padding: 1.5rem 1rem 3rem;
+.mono {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+}
+
+@media (max-width: 960px) {
+  .grid--main {
+    grid-template-columns: 1fr;
   }
 
-  h1 {
-    font-size: 1.6rem;
+  .panel-actions {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 640px) {
+  .app-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  main,
+  .app-shell {
+    padding: 1.5rem 1rem 3rem;
   }
 }

--- a/app/ui/src/types.ts
+++ b/app/ui/src/types.ts
@@ -11,8 +11,18 @@ export interface ProxySettings {
   password: string;
 }
 
+export type DownloadMode = "by_artist" | "single_folder";
+
+export interface DownloadSettings {
+  mode: DownloadMode;
+  active_template: string;
+  by_artist_template: string;
+  single_folder_template: string;
+}
+
 export interface AppSettings {
   proxy: ProxySettings;
+  download: DownloadSettings;
 }
 
 export interface JobModel {

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,171 @@
+# SpotiFLAC API v1
+
+Документ описывает REST- и WebSocket-интерфейсы, предоставляемые сервисом SpotiFLAC. Он предназначен для интеграции с внешними сервисами, автоматизацией и созданием собственных пользовательских интерфейсов.
+
+## Базовая информация
+
+* Базовый URL: `http://<host>:8080`
+* Все ответы — в формате JSON (если не указано иное).
+* Время указано в формате ISO 8601 UTC.
+* CORS открыт для всех доменов (`Access-Control-Allow-Origin: *`).
+
+## Структура настроек
+
+```jsonc
+{
+  "proxy": {
+    "enabled": false,
+    "host": "",
+    "port": null,
+    "username": "",
+    "password": ""
+  },
+  "download": {
+    "mode": "by_artist",          // или "single_folder"
+    "active_template": "{artist}/{album}/{track:02d} - {title}.{ext}",
+    "by_artist_template": "{artist}/{album}/{track:02d} - {title}.{ext}",
+    "single_folder_template": "{artist} - {album} - {track:02d} - {title}.{ext}"
+  }
+}
+```
+
+Поле `active_template` вычисляется автоматически на основе выбранного режима и служит для отображения. При сохранении настроек достаточно передать значения `mode`, `by_artist_template` и `single_folder_template`.
+
+## Эндпоинты настроек
+
+### `GET /settings`
+
+Возвращает сохранённые настройки прокси и режима сохранения файлов. В случае отсутствия файла конфигурации применяется окружение контейнера (`PATH_TEMPLATE`, `PATH_TEMPLATE_FLAT`).
+
+### `PUT /settings`
+
+Обновляет настройки. Тело запроса соответствует структуре, описанной выше. Можно передавать только одну из секций (`proxy` или `download`) — отсутствующие поля не изменяются.
+
+Пример запроса для переключения режима на «в одну папку»:
+
+```http
+PUT /settings
+Content-Type: application/json
+
+{
+  "download": {
+    "mode": "single_folder"
+  }
+}
+```
+
+Ответ содержит полную структуру настроек с вычисленным `active_template`.
+
+## Задачи загрузки
+
+### `POST /jobs`
+
+Создаёт задачу на загрузку.
+
+```json
+{
+  "provider": "spotify",
+  "store": "qobuz",
+  "url": "https://open.spotify.com/album/...",
+  "quality": "LOSSLESS",
+  "path_template": "{artist} - {title}.{ext}"
+}
+```
+
+Параметр `path_template` необязателен. При пустом значении используется `download.active_template` из настроек.
+
+Ответ:
+
+```json
+{
+  "job": {
+    "id": "4d9c6ce6d2a44d00a67e77f6a31d54dd",
+    "status": "pending",
+    "progress": 0.0,
+    "total_tracks": 0,
+    "completed_tracks": 0,
+    "failed_tracks": 0,
+    "provider": "spotify",
+    "store": "qobuz",
+    "source_url": "https://open.spotify.com/album/...",
+    "quality": "LOSSLESS",
+    "path_template": "{artist} - {title}.{ext}",
+    "output_dir": "/downloads",
+    "logs": [],
+    "created_at": "2024-06-01T09:10:00.000000",
+    "updated_at": "2024-06-01T09:10:00.000000",
+    "finished_at": null,
+    "message": null,
+    "error": null
+  }
+}
+```
+
+### `GET /jobs`
+
+Возвращает массив всех задач (активных и завершённых). Для постраничной навигации можно фильтровать на клиенте — API отдаёт полный список.
+
+### `GET /jobs/{id}`
+
+Получает детальное описание задачи по идентификатору. При отсутствии возвращает `404`.
+
+### `DELETE /jobs/{id}`
+
+Отменяет выполнение. В случае успеха — `{ "cancelled": true }`.
+
+### `GET /jobs/{id}/logs`
+
+Возвращает массив строк с логами в порядке появления. Для потокового получения логов используйте WebSocket.
+
+## Списки и метаданные
+
+### `GET /providers`
+
+Содержит два массива: `playlists` (поддерживаемые источники) и `stores` (магазины загрузки).
+
+### `GET /files`
+
+Возвращает массив объектов `{ "path": "...", "size": 1234, "modified_at": "..." }` из каталога `/downloads`, отсортированных по дате.
+
+### `POST /auth/{provider}`
+
+Сохраняет токены/куки провайдера. В теле запроса передаётся объект `{ "data": { ... } }`, который записывается в `/config/providers/<provider>.json`.
+
+## Служебные эндпоинты
+
+* `GET /healthz` — готовность контейнера.
+* `GET /readyz` — статус очереди ("ready" или "starting").
+* `GET /metrics` — метрика `spotiflac_jobs_total` в формате Prometheus.
+
+## WebSocket: `GET /ws/progress`
+
+Позволяет получать обновления задач в реальном времени. Сообщения идентичны объекту `job` в REST-ответах.
+
+```json
+{
+  "id": "4d9c6ce6d2a44d00a67e77f6a31d54dd",
+  "status": "running",
+  "progress": 0.45,
+  "completed_tracks": 9,
+  "total_tracks": 20,
+  "logs": ["Старт загрузки", "Загружен трек 9/20"]
+}
+```
+
+Соединение можно открывать как из браузера, так и из серверного приложения. URL формируется из базового адреса API, заменяя протокол `http`/`https` на `ws`/`wss`.
+
+## Типичные сценарии интеграции
+
+1. Получить доступные магазины (`GET /providers`).
+2. Настроить прокси/структуру файлов (`PUT /settings`).
+3. Отправить задачу (`POST /jobs`).
+4. Подписаться на WebSocket для мониторинга прогресса.
+5. После завершения задачи запросить `GET /files` для отображения результатов.
+
+## Коды ошибок
+
+* `400 Bad Request` — ошибка валидации данных (например, отсутствует URL или неверный порт прокси).
+* `404 Not Found` — запрошенный ресурс отсутствует.
+* `500 Internal Server Error` — неожиданные ошибки внутри сервиса.
+
+Рекомендуется обрабатывать текст сообщения (`detail`) в теле ответа для отображения пользователю.


### PR DESCRIPTION
## Summary
- добавить в настройки приложения выбор режима сохранения файлов, расширить API и CLI для работы с шаблонами
- обновить панель управления: современный компактный дизайн, переключатель режима и подсказки по шаблонам
- подготовить документацию для интеграции (docs/API.md) и обновить README с новой возможностью

## Testing
- pytest
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d52d692824832aa3d4912a465e80e7