### PR TITLE
Добавить историю загрузок и остановку задач

### DIFF
--- a/app/api/main.py
+++ b/app/api/main.py
@@ -12,6 +12,8 @@ from app.api.schemas import (
     AppSettingsModel,
     FileItem,
     FilesResponse,
+    HistoryItem,
+    HistoryResponse,
     JobCreateRequest,
     JobModel,
     JobResponse,
@@ -155,6 +157,21 @@ async def cancel_job(job_id: str) -> Dict[str, object]:
 @app.get("/files", response_model=FilesResponse)
 async def list_files() -> FilesResponse:
     files = [FileItem(**item) for item in service.get_files()]
+    return FilesResponse(files=files)
+
+
+@app.get("/history", response_model=HistoryResponse)
+async def history() -> HistoryResponse:
+    items = [HistoryItem(**item) for item in service.get_history()]
+    return HistoryResponse(history=items)
+
+
+@app.get("/jobs/{job_id}/files", response_model=FilesResponse)
+async def job_files(job_id: str) -> FilesResponse:
+    snapshot = service.get_job(job_id)
+    if not snapshot:
+        raise HTTPException(status_code=404, detail="Задача не найдена")
+    files = [FileItem(**item) for item in service.get_job_files(job_id)]
     return FilesResponse(files=files)
 
 

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -28,6 +28,7 @@ class JobModel(BaseModel):
     source_url: str
     quality: Optional[str]
     path_template: str
+    mode: str
     created_at: str
     updated_at: str
     finished_at: Optional[str]
@@ -40,6 +41,7 @@ class JobModel(BaseModel):
     error: Optional[str]
     output_dir: str
     logs: List[str]
+    collection_name: Optional[str]
 
 
 class JobResponse(BaseModel):
@@ -63,6 +65,21 @@ class FileItem(BaseModel):
 
 class FilesResponse(BaseModel):
     files: List[FileItem]
+
+
+class HistoryItem(BaseModel):
+    job_id: str
+    playlist: str
+    status: str
+    created_at: str
+    finished_at: Optional[str]
+    total_tracks: int
+    completed_tracks: int
+    failed_tracks: int
+
+
+class HistoryResponse(BaseModel):
+    history: List[HistoryItem]
 
 
 class ProxySettingsModel(BaseModel):

--- a/app/core/models.py
+++ b/app/core/models.py
@@ -89,6 +89,7 @@ class DownloadJob:
     source_url: str
     quality: Optional[str]
     path_template: str
+    mode: DownloadMode = DownloadMode.BY_ARTIST
     created_at: datetime = field(default_factory=datetime.utcnow)
     updated_at: datetime = field(default_factory=datetime.utcnow)
     finished_at: Optional[datetime] = None
@@ -101,6 +102,7 @@ class DownloadJob:
     error: Optional[str] = None
     output_dir: str = ""
     logs: List[str] = field(default_factory=list)
+    collection_name: Optional[str] = None
 
     def touch(self) -> None:
         """Обновляет метку времени обновления."""
@@ -122,6 +124,8 @@ class DownloadJob:
         data["provider"] = self.provider.value
         data["store"] = self.store.value
         data["status"] = self.status.value
+        data["mode"] = self.mode.value
+        data["collection_name"] = self.collection_name
         return data
 
 
@@ -135,6 +139,7 @@ class JobSnapshot:
     source_url: str
     quality: Optional[str]
     path_template: str
+    mode: str
     created_at: str
     updated_at: str
     finished_at: Optional[str]
@@ -147,6 +152,7 @@ class JobSnapshot:
     error: Optional[str]
     output_dir: str
     logs: List[str]
+    collection_name: Optional[str]
 
 
 @dataclass

--- a/app/infra/app_config.py
+++ b/app/infra/app_config.py
@@ -11,7 +11,7 @@ from app.core.models import DownloadMode
 from app.infra.settings import Settings
 
 DEFAULT_ARTIST_TEMPLATE = "{artist}/{album}/{track:02d} - {title}.{ext}"
-DEFAULT_SINGLE_TEMPLATE = "{artist} - {album} - {track:02d} - {title}.{ext}"
+DEFAULT_SINGLE_TEMPLATE = "{playlist}/{track:02d} - {artist} - {title}.{ext}"
 
 
 @dataclass

--- a/app/ui/src/api.ts
+++ b/app/ui/src/api.ts
@@ -1,4 +1,12 @@
-import type { AppSettings, FilesResponse, JobModel, JobResponse, JobsListResponse, ProvidersResponse } from "./types";
+import type {
+  AppSettings,
+  FilesResponse,
+  HistoryResponse,
+  JobModel,
+  JobResponse,
+  JobsListResponse,
+  ProvidersResponse
+} from "./types";
 
 const API_BASE = (import.meta.env.VITE_API_BASE as string | undefined) ?? "/api";
 
@@ -49,6 +57,14 @@ export async function fetchJobs(): Promise<JobsListResponse> {
 
 export async function fetchFiles(): Promise<FilesResponse> {
   return request<FilesResponse>("/files");
+}
+
+export async function fetchHistory(): Promise<HistoryResponse> {
+  return request<HistoryResponse>("/history");
+}
+
+export async function fetchJobFiles(jobId: string): Promise<FilesResponse> {
+  return request<FilesResponse>(`/jobs/${jobId}/files`);
 }
 
 export async function fetchSettings(): Promise<AppSettings> {
@@ -108,4 +124,8 @@ export function subscribeProgress(onUpdate: (job: JobModel) => void): () => void
     }
   };
   return () => socket.close();
+}
+
+export async function cancelJob(jobId: string): Promise<void> {
+  await request(`/jobs/${jobId}`, { method: "DELETE" });
 }

--- a/app/ui/src/main.css
+++ b/app/ui/src/main.css
@@ -284,6 +284,84 @@ button:disabled {
   gap: 0.65rem;
 }
 
+.history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.history-card {
+  padding: 0.9rem 1rem;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  transition: border 0.2s ease, background 0.2s ease;
+}
+
+.history-card.open {
+  border-color: rgba(59, 130, 246, 0.35);
+  background: rgba(15, 23, 42, 0.7);
+}
+
+.history-toggle {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  gap: 1rem;
+  background: transparent;
+  border: none;
+  padding: 0;
+  color: inherit;
+  cursor: pointer;
+  box-shadow: none;
+  border-radius: 0;
+  text-align: left;
+}
+
+.history-toggle:hover:not(:disabled) {
+  transform: none;
+  box-shadow: none;
+  color: #f8fafc;
+}
+
+.history-toggle:focus-visible {
+  outline: 2px solid rgba(56, 189, 248, 0.5);
+  outline-offset: 4px;
+}
+
+.history-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.history-info strong {
+  font-size: 1rem;
+}
+
+.history-subline {
+  font-size: 0.85rem;
+}
+
+.history-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.35rem;
+}
+
+.history-files {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  margin-top: 0.75rem;
+}
+
+.history-files .file-card {
+  background: rgba(15, 23, 42, 0.75);
+}
+
 .file-card {
   display: flex;
   flex-direction: column;
@@ -390,6 +468,22 @@ button:disabled {
 
 .mono {
   font-family: "JetBrains Mono", "Fira Code", monospace;
+}
+
+.small-button {
+  padding: 0.45rem 1rem;
+  font-size: 0.85rem;
+}
+
+.danger-button {
+  background: rgba(248, 113, 113, 0.18);
+  color: #fecaca;
+  box-shadow: none;
+}
+
+.danger-button:hover:not(:disabled) {
+  background: rgba(248, 113, 113, 0.28);
+  box-shadow: none;
 }
 
 @media (max-width: 960px) {

--- a/app/ui/src/types.ts
+++ b/app/ui/src/types.ts
@@ -32,6 +32,7 @@ export interface JobModel {
   source_url: string;
   quality: string | null;
   path_template: string;
+  mode: DownloadMode;
   created_at: string;
   updated_at: string;
   finished_at: string | null;
@@ -44,6 +45,7 @@ export interface JobModel {
   error: string | null;
   output_dir: string;
   logs: string[];
+  collection_name: string | null;
 }
 
 export interface JobResponse {
@@ -62,4 +64,19 @@ export interface FileItem {
 
 export interface FilesResponse {
   files: FileItem[];
+}
+
+export interface HistoryItem {
+  job_id: string;
+  playlist: string;
+  status: string;
+  created_at: string;
+  finished_at: string | null;
+  total_tracks: number;
+  completed_tracks: number;
+  failed_tracks: number;
+}
+
+export interface HistoryResponse {
+  history: HistoryItem[];
 }

--- a/tests/core/test_service.py
+++ b/tests/core/test_service.py
@@ -331,6 +331,6 @@ async def test_режим_одной_папки_использует_шабло�
             path_template=None,
         )
         снимок = await сервис.submit_job(запрос)
-        assert снимок.path_template == "{artist} - {album} - {track:02d} - {title}.{ext}"
+        assert снимок.path_template == "{playlist}/{track:02d} - {artist} - {title}.{ext}"
     finally:
         await сервис.stop()


### PR DESCRIPTION
## Summary
- реализована история загрузок плейлистов с новым API и интерфейсом
- добавлена кнопка остановки задач и группировка файлов по имени плейлиста
- обновлён шаблон сохранения "в одну папку" для создания каталога плейлиста

## Testing
- pytest
- npm --prefix app/ui run build

------
https://chatgpt.com/codex/tasks/task_e_68d53a9084c0832aad1ca6546e720541