### PR TITLE
feat: обновить оформление панели управления

### DIFF
--- a/app/infra/app_config.py
+++ b/app/infra/app_config.py
@@ -68,7 +68,7 @@ class ProxySettings:
 class DownloadSettings:
     """Параметры структуры каталогов загрузок."""
 
-    mode: DownloadMode = DownloadMode.BY_ARTIST
+    mode: DownloadMode = DownloadMode.SINGLE_FOLDER
     by_artist_template: str = DEFAULT_ARTIST_TEMPLATE
     single_folder_template: str = DEFAULT_SINGLE_TEMPLATE
 

--- a/app/ui/src/App.tsx
+++ b/app/ui/src/App.tsx
@@ -108,7 +108,7 @@ const App: React.FC = () => {
   const [form, setForm] = useState<FormState>(DEFAULT_FORM);
   const [proxyForm, setProxyForm] = useState<ProxyFormState>(DEFAULT_PROXY_FORM);
   const [downloadSettings, setDownloadSettings] = useState<DownloadSettings | null>(null);
-  const [autoTemplate, setAutoTemplate] = useState<string>(DEFAULT_BY_ARTIST_TEMPLATE);
+  const [autoTemplate, setAutoTemplate] = useState<string>(DEFAULT_SINGLE_TEMPLATE);
   const [pathTemplateEdited, setPathTemplateEdited] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -212,12 +212,16 @@ const App: React.FC = () => {
         setHistory(historyResponse.history);
         setHistoryFiles({});
         setExpandedHistoryId(null);
+        const activeTemplate = templateForMode(
+          settingsResponse.download.mode,
+          settingsResponse.download
+        );
         setForm((prev) => ({
           ...prev,
           store: prov.stores[0] ?? prev.store,
-          pathTemplate: prev.pathTemplate || settingsResponse.download.active_template
+          pathTemplate: prev.pathTemplate || activeTemplate
         }));
-        setAutoTemplate(settingsResponse.download.active_template);
+        setAutoTemplate(activeTemplate);
         setPathTemplateEdited(false);
         setProxyForm({
           enabled: settingsResponse.proxy.enabled,
@@ -483,15 +487,23 @@ const App: React.FC = () => {
   const statusLabel = (status: string) => STATUS_STYLE[status]?.label ?? status;
   const statusColor = (status: string) => STATUS_STYLE[status]?.color ?? "#cbd5f5";
 
+  const activeDownloadMode: DownloadMode = downloadSettings?.mode ?? "single_folder";
+
   return (
     <main className="app-shell">
       <header className="app-header">
-        <div>
-          <h1>SpotiFLAC Control Center</h1>
-          <p className="muted">Управляйте загрузками, сетевыми настройками и структурой файлов из одного окна.</p>
+        <div className="header-brand">
+          <span className="brand-mark">SF</span>
+          <div>
+            <h1>SpotiFLAC Studio</h1>
+            <p className="muted">
+              Панель управления загрузками с акцентом на скорость, чистоту каталога и мгновенный контроль.
+            </p>
+          </div>
         </div>
         <div className="header-actions">
           <span className="chip">API v1</span>
+          <span className="chip chip--accent">Lossless Ready</span>
         </div>
       </header>
 
@@ -509,17 +521,17 @@ const App: React.FC = () => {
           <div className="segmented">
             <button
               type="button"
-              className={downloadSettings?.mode === "by_artist" ? "active" : ""}
+              className={activeDownloadMode === "by_artist" ? "active" : ""}
               onClick={() => handleDownloadModeChange("by_artist")}
             >
               По артистам
             </button>
             <button
               type="button"
-              className={downloadSettings?.mode === "single_folder" ? "active" : ""}
+              className={activeDownloadMode === "single_folder" ? "active" : ""}
               onClick={() => handleDownloadModeChange("single_folder")}
             >
-              В одну папку
+              Сохранение в папку
             </button>
           </div>
           <div className="template-preview">

--- a/app/ui/src/main.css
+++ b/app/ui/src/main.css
@@ -1,126 +1,216 @@
 :root {
   color-scheme: dark;
-  font-family: "Inter", "Segoe UI", sans-serif;
-  background: #0a1022;
-  color: #e2e8f0;
+  font-family: "Manrope", "Segoe UI", sans-serif;
+  background: #05060f;
+  color: #f8fafc;
 }
 
 body {
   margin: 0;
   min-height: 100vh;
-  background: radial-gradient(circle at top, rgba(56, 189, 248, 0.12), transparent 45%),
-    radial-gradient(circle at bottom, rgba(103, 232, 249, 0.12), transparent 40%),
-    #060916;
+  background: radial-gradient(circle at 20% 0%, rgba(99, 102, 241, 0.22), transparent 55%),
+    radial-gradient(circle at 80% 10%, rgba(236, 72, 153, 0.2), transparent 45%),
+    linear-gradient(180deg, #05060f 0%, #070a16 100%);
+  position: relative;
+}
+
+body::before,
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  opacity: 0.45;
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+body::before {
+  background: radial-gradient(circle at 15% 30%, rgba(59, 130, 246, 0.35), transparent 60%);
+  filter: blur(90px);
+}
+
+body::after {
+  background: radial-gradient(circle at 85% 75%, rgba(244, 114, 182, 0.28), transparent 55%);
+  filter: blur(110px);
 }
 
 a {
   color: inherit;
+  text-decoration: none;
 }
 
 main,
 .app-shell {
-  max-width: 1200px;
+  max-width: 1280px;
   margin: 0 auto;
-  padding: 2rem 1.5rem 4rem;
+  padding: 2.5rem 2rem 4rem;
+  position: relative;
+  z-index: 1;
 }
 
 .app-header {
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
-  gap: 1rem;
-  margin-bottom: 1.5rem;
+  align-items: center;
+  gap: 2rem;
+  padding: 1.75rem 2rem;
+  margin-bottom: 2.25rem;
+  background: rgba(12, 15, 32, 0.78);
+  border: 1px solid rgba(99, 102, 241, 0.25);
+  border-radius: 28px;
+  box-shadow: 0 30px 80px rgba(6, 9, 24, 0.65);
+  backdrop-filter: blur(28px);
+}
+
+.header-brand {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  max-width: 720px;
+}
+
+.brand-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(79, 70, 229, 0.85), rgba(236, 72, 153, 0.9));
+  color: #0b1024;
+  font-weight: 700;
+  font-size: 1.25rem;
+  letter-spacing: 0.08em;
+  box-shadow: 0 18px 35px rgba(99, 102, 241, 0.4);
 }
 
 .app-header h1 {
-  font-size: 2.1rem;
+  margin: 0 0 0.6rem;
+  font-size: 2.25rem;
   font-weight: 700;
-  margin: 0 0 0.5rem;
 }
 
 .muted {
-  color: #94a3b8;
-  font-size: 0.9rem;
-  line-height: 1.5;
+  color: #a5b4d4;
+  font-size: 0.92rem;
+  line-height: 1.6;
 }
 
 .header-actions {
   display: flex;
   gap: 0.75rem;
+  align-items: center;
 }
 
 .chip {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
-  padding: 0.35rem 0.8rem;
+  gap: 0.4rem;
+  padding: 0.45rem 1.1rem;
   border-radius: 999px;
-  background: rgba(59, 130, 246, 0.25);
-  color: #bfdbfe;
-  font-size: 0.85rem;
-  letter-spacing: 0.02em;
+  background: rgba(129, 140, 248, 0.16);
+  border: 1px solid rgba(99, 102, 241, 0.45);
+  color: #c7d2fe;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.chip--accent {
+  background: rgba(236, 72, 153, 0.16);
+  border-color: rgba(236, 72, 153, 0.48);
+  color: #fbcfe8;
 }
 
 .grid {
   display: grid;
-  gap: 1.25rem;
-  margin-bottom: 1.5rem;
+  gap: 1.75rem;
+  margin-bottom: 2rem;
 }
 
 .grid--two {
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
   align-items: stretch;
 }
 
 .grid--main {
-  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1.2fr);
+  align-items: start;
 }
 
 .panel {
-  background: rgba(12, 19, 38, 0.88);
-  border-radius: 20px;
-  padding: 1.5rem;
-  box-shadow: 0 18px 45px rgba(10, 15, 30, 0.5);
-  backdrop-filter: blur(18px);
-  border: 1px solid rgba(148, 163, 184, 0.12);
+  position: relative;
+  background: linear-gradient(155deg, rgba(10, 14, 33, 0.92), rgba(9, 13, 26, 0.75));
+  border-radius: 26px;
+  padding: 1.8rem 2rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 24px 60px rgba(8, 11, 24, 0.65);
+  backdrop-filter: blur(24px);
+  overflow: hidden;
+}
+
+.panel::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 90% 0%, rgba(59, 130, 246, 0.12), transparent 55%);
+  pointer-events: none;
+  opacity: 0.6;
 }
 
 .panel--highlight {
-  background: linear-gradient(160deg, rgba(15, 118, 110, 0.25), rgba(15, 23, 42, 0.75));
-  border: 1px solid rgba(45, 212, 191, 0.25);
+  background: linear-gradient(160deg, rgba(15, 118, 110, 0.4), rgba(8, 14, 30, 0.82));
+  border-color: rgba(45, 212, 191, 0.35);
+}
+
+.panel--highlight::after {
+  background: radial-gradient(circle at 15% 15%, rgba(20, 184, 166, 0.22), transparent 65%);
+}
+
+.panel--compact {
+  padding: 1.35rem 1.7rem;
+  border-radius: 22px;
+}
+
+.panel::before {
+  content: "";
+  position: absolute;
+  inset: 1px;
+  border-radius: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.08);
+  pointer-events: none;
 }
 
 .panel-header {
+  position: relative;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 1rem;
-  margin-bottom: 1.25rem;
+  gap: 1.2rem;
+  margin-bottom: 1.4rem;
 }
 
 .panel-header h2 {
-  margin: 0 0 0.35rem;
-  font-size: 1.25rem;
+  margin: 0 0 0.45rem;
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.panel-header--compact {
+  margin-bottom: 1rem;
 }
 
 .panel-form {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-}
-
-.panel--compact {
-  padding: 1.1rem 1.4rem;
-}
-
-.panel-header--compact {
-  margin-bottom: 0.75rem;
+  gap: 1.15rem;
 }
 
 .proxy-form {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 1rem;
 }
 
 .proxy-row {
@@ -133,73 +223,45 @@ main,
 
 .proxy-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 0.75rem;
-}
-
-.switch--inline {
-  gap: 0.5rem;
-}
-
-.switch--inline span {
-  font-size: 0.85rem;
-}
-
-.toggle-line {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.switch {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.65rem;
-  cursor: pointer;
-  font-weight: 500;
-  color: #e2e8f0;
-}
-
-.switch input {
-  width: 20px;
-  height: 20px;
-  accent-color: #38bdf8;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.85rem;
 }
 
 label {
   display: block;
-  font-size: 0.85rem;
-  margin-bottom: 0.4rem;
-  color: #a5b4fc;
+  font-size: 0.8rem;
+  margin-bottom: 0.45rem;
+  color: #c7d2fe;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.05em;
 }
 
 input:not([type="checkbox"]),
 select,
 textarea {
   width: 100%;
-  padding: 0.6rem 0.75rem;
-  border-radius: 12px;
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  background: rgba(15, 23, 42, 0.6);
-  color: #e2e8f0;
+  padding: 0.7rem 0.85rem;
+  border-radius: 14px;
+  border: 1px solid rgba(129, 140, 248, 0.25);
+  background: rgba(9, 13, 26, 0.7);
+  color: #f8fafc;
   font-size: 0.95rem;
-  transition: border 0.2s ease, box-shadow 0.2s ease;
+  transition: border 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 
 input:not([type="checkbox"]):focus,
 select:focus,
 textarea:focus {
   outline: none;
-  border-color: #38bdf8;
-  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.35);
+  border-color: rgba(129, 140, 248, 0.65);
+  box-shadow: 0 0 0 3px rgba(129, 140, 248, 0.28);
+  transform: translateY(-1px);
 }
 
 .form-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.1rem;
 }
 
 .form-grid .span-2 {
@@ -213,19 +275,21 @@ textarea:focus {
 }
 
 button {
-  padding: 0.6rem 1.4rem;
+  padding: 0.65rem 1.6rem;
   border-radius: 999px;
   border: none;
-  background: linear-gradient(135deg, #22d3ee, #3b82f6);
-  color: #0f172a;
+  background: linear-gradient(135deg, #6366f1, #ec4899);
+  color: #05060f;
   font-weight: 600;
+  font-size: 0.95rem;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 20px 45px rgba(99, 102, 241, 0.35);
 }
 
 button:hover:not(:disabled) {
-  transform: translateY(-1px);
-  box-shadow: 0 18px 40px rgba(37, 99, 235, 0.35);
+  transform: translateY(-2px);
+  box-shadow: 0 26px 55px rgba(99, 102, 241, 0.45);
 }
 
 button:disabled {
@@ -234,109 +298,125 @@ button:disabled {
   box-shadow: none;
 }
 
+.small-button {
+  padding: 0.5rem 1.1rem;
+  font-size: 0.85rem;
+}
+
 .ghost-button {
-  background: rgba(59, 130, 246, 0.12);
-  color: #bfdbfe;
+  background: transparent;
+  color: #cbd5ff;
+  border: 1px solid rgba(129, 140, 248, 0.35);
   box-shadow: none;
 }
 
 .ghost-button:hover:not(:disabled) {
-  background: rgba(59, 130, 246, 0.2);
+  background: rgba(129, 140, 248, 0.12);
+}
+
+.danger-button {
+  background: rgba(248, 113, 113, 0.18);
+  color: #fecaca;
+  box-shadow: none;
+}
+
+.danger-button:hover:not(:disabled) {
+  background: rgba(248, 113, 113, 0.3);
 }
 
 .panel-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 0.75rem;
+  gap: 0.85rem;
 }
 
 .alert {
-  padding: 0.75rem 1rem;
-  border-radius: 16px;
-  margin-bottom: 1rem;
-  border: 1px solid rgba(59, 130, 246, 0.35);
-  background: rgba(59, 130, 246, 0.15);
+  padding: 0.85rem 1.1rem;
+  border-radius: 18px;
+  margin-bottom: 1.2rem;
+  border: 1px solid rgba(129, 140, 248, 0.32);
+  background: rgba(99, 102, 241, 0.16);
 }
 
 .alert.success {
-  border-color: rgba(45, 212, 191, 0.35);
-  background: rgba(45, 212, 191, 0.15);
+  border-color: rgba(20, 184, 166, 0.4);
+  background: rgba(45, 212, 191, 0.16);
 }
 
 .alert.error {
   border-color: rgba(248, 113, 113, 0.45);
-  background: rgba(248, 113, 113, 0.18);
+  background: rgba(248, 113, 113, 0.22);
 }
 
 .segmented {
   display: inline-flex;
-  padding: 0.25rem;
+  padding: 0.35rem;
   border-radius: 999px;
-  background: rgba(15, 23, 42, 0.65);
-  border: 1px solid rgba(148, 163, 184, 0.16);
-  margin-bottom: 1rem;
+  background: rgba(10, 12, 24, 0.85);
+  border: 1px solid rgba(129, 140, 248, 0.35);
+  margin-bottom: 1.2rem;
 }
 
 .segmented button {
   background: transparent;
-  color: #cbd5f5;
-  padding: 0.45rem 1rem;
+  color: #cbd5ff;
+  padding: 0.5rem 1.15rem;
   border-radius: 999px;
   border: none;
   box-shadow: none;
-  transition: background 0.2s ease, color 0.2s ease;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.segmented button:hover:not(:disabled) {
+  transform: translateY(-1px);
 }
 
 .segmented button.active {
-  background: linear-gradient(135deg, rgba(34, 211, 238, 0.8), rgba(59, 130, 246, 0.9));
-  color: #0f172a;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.85), rgba(236, 72, 153, 0.9));
+  color: #05060f;
 }
 
 .template-preview {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  margin-bottom: 1.2rem;
-  padding: 1rem;
-  border-radius: 16px;
-  background: rgba(15, 23, 42, 0.55);
-  border: 1px solid rgba(148, 163, 184, 0.16);
+  gap: 0.55rem;
+  margin-bottom: 1.35rem;
+  padding: 1.1rem 1.2rem;
+  border-radius: 18px;
+  background: rgba(9, 13, 26, 0.78);
+  border: 1px solid rgba(129, 140, 248, 0.28);
 }
 
 .template-preview code {
   font-family: "JetBrains Mono", "Fira Code", monospace;
-  font-size: 0.9rem;
+  font-size: 0.92rem;
   color: #f8fafc;
 }
 
 .hint {
-  margin-top: 0.4rem;
+  margin-top: 0.45rem;
   font-size: 0.8rem;
 }
 
+.history-list,
 .files-list {
   display: flex;
   flex-direction: column;
-  gap: 0.65rem;
-}
-
-.history-list {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.8rem;
 }
 
 .history-card {
-  padding: 0.9rem 1rem;
-  border-radius: 16px;
-  background: rgba(15, 23, 42, 0.55);
-  border: 1px solid rgba(148, 163, 184, 0.14);
-  transition: border 0.2s ease, background 0.2s ease;
+  position: relative;
+  padding: 1rem 1.15rem;
+  border-radius: 18px;
+  background: rgba(10, 13, 26, 0.78);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  transition: border 0.2s ease, transform 0.2s ease, background 0.2s ease;
 }
 
 .history-card.open {
-  border-color: rgba(59, 130, 246, 0.35);
-  background: rgba(15, 23, 42, 0.7);
+  border-color: rgba(129, 140, 248, 0.4);
+  background: rgba(12, 16, 33, 0.85);
 }
 
 .history-toggle {
@@ -357,19 +437,18 @@ button:disabled {
 
 .history-toggle:hover:not(:disabled) {
   transform: none;
-  box-shadow: none;
   color: #f8fafc;
 }
 
 .history-toggle:focus-visible {
-  outline: 2px solid rgba(56, 189, 248, 0.5);
+  outline: 2px solid rgba(129, 140, 248, 0.45);
   outline-offset: 4px;
 }
 
 .history-info {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.4rem;
 }
 
 .history-info strong {
@@ -384,28 +463,24 @@ button:disabled {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  gap: 0.35rem;
+  gap: 0.45rem;
 }
 
 .history-files {
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
-  margin-top: 0.75rem;
-}
-
-.history-files .file-card {
-  background: rgba(15, 23, 42, 0.75);
+  gap: 0.65rem;
+  margin-top: 0.85rem;
 }
 
 .file-card {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
-  padding: 0.9rem 1rem;
-  border-radius: 14px;
-  background: rgba(30, 41, 59, 0.78);
-  border: 1px solid rgba(148, 163, 184, 0.12);
+  padding: 0.95rem 1.05rem;
+  border-radius: 16px;
+  background: rgba(12, 16, 33, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.16);
 }
 
 .file-card strong {
@@ -414,8 +489,8 @@ button:disabled {
 }
 
 .file-card span {
-  font-size: 0.85rem;
-  color: #94a3b8;
+  font-size: 0.82rem;
+  color: #94a3c3;
 }
 
 .table-wrapper {
@@ -426,100 +501,116 @@ button:disabled {
   width: 100%;
   border-collapse: collapse;
   font-size: 0.9rem;
+  position: relative;
 }
 
 .table th,
 .table td {
-  padding: 0.7rem 0.6rem;
+  padding: 0.75rem 0.7rem;
   text-align: left;
   border-bottom: 1px solid rgba(148, 163, 184, 0.12);
 }
 
 .table tbody tr {
-  transition: background 0.15s ease, transform 0.15s ease;
+  transition: background 0.18s ease, transform 0.18s ease;
   cursor: pointer;
 }
 
 .table tbody tr:hover {
-  background: rgba(59, 130, 246, 0.08);
+  background: rgba(99, 102, 241, 0.12);
   transform: translateY(-1px);
 }
 
 .empty-cell {
   text-align: center;
-  padding: 1.5rem;
-  color: #64748b;
+  padding: 1.7rem 1rem;
+  color: #7c8caa;
 }
 
 .status-badge {
   display: inline-flex;
   align-items: center;
   gap: 0.45rem;
-  padding: 0.35rem 0.8rem;
+  padding: 0.38rem 0.9rem;
   border-radius: 999px;
-  font-size: 0.8rem;
+  font-size: 0.82rem;
   font-weight: 600;
-  background: rgba(15, 23, 42, 0.75);
+  background: rgba(10, 13, 26, 0.78);
   border: 1px solid rgba(148, 163, 184, 0.18);
 }
 
 .status-badge .dot {
   display: inline-flex;
-  width: 8px;
-  height: 8px;
+  width: 9px;
+  height: 9px;
   border-radius: 999px;
 }
 
 .progress-bar {
-  height: 8px;
-  border-radius: 6px;
-  background: rgba(51, 65, 85, 0.6);
+  height: 9px;
+  border-radius: 999px;
+  background: rgba(45, 55, 72, 0.55);
   overflow: hidden;
 }
 
 .progress-bar span {
   display: block;
   height: 100%;
-  border-radius: 6px;
-  background: linear-gradient(135deg, #22d3ee, #3b82f6);
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.9), rgba(236, 72, 153, 0.9));
   transition: width 0.3s ease;
 }
 
 .logs-box {
-  max-height: 260px;
+  max-height: 280px;
   overflow-y: auto;
-  padding: 1rem;
-  border-radius: 14px;
-  background: rgba(15, 23, 42, 0.6);
-  border: 1px solid rgba(148, 163, 184, 0.15);
+  padding: 1.15rem 1.25rem;
+  border-radius: 18px;
+  background: rgba(9, 12, 24, 0.82);
+  border: 1px solid rgba(129, 140, 248, 0.24);
   font-family: "JetBrains Mono", "Fira Code", monospace;
-  font-size: 0.85rem;
-  line-height: 1.4;
+  font-size: 0.86rem;
+  line-height: 1.45;
+  color: #cbd5ff;
 }
 
 .logs-box p {
-  margin: 0 0 0.4rem;
-  color: #cbd5f5;
+  margin: 0 0 0.45rem;
 }
 
 .mono {
   font-family: "JetBrains Mono", "Fira Code", monospace;
 }
 
-.small-button {
-  padding: 0.45rem 1rem;
-  font-size: 0.85rem;
+.switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.7rem;
+  cursor: pointer;
+  font-weight: 500;
+  color: #f8fafc;
 }
 
-.danger-button {
-  background: rgba(248, 113, 113, 0.18);
-  color: #fecaca;
-  box-shadow: none;
+.switch--inline {
+  gap: 0.55rem;
 }
 
-.danger-button:hover:not(:disabled) {
-  background: rgba(248, 113, 113, 0.28);
-  box-shadow: none;
+.switch--inline span {
+  font-size: 0.88rem;
+}
+
+.switch input {
+  width: 20px;
+  height: 20px;
+  accent-color: #6366f1;
+}
+
+.hint,
+.history-subline,
+.file-card span,
+.logs-box p,
+.muted {
+  letter-spacing: 0.01em;
 }
 
 @media (max-width: 960px) {
@@ -533,14 +624,20 @@ button:disabled {
   }
 }
 
-@media (max-width: 640px) {
+@media (max-width: 720px) {
+  main,
+  .app-shell {
+    padding: 2rem 1.4rem 3.5rem;
+  }
+
   .app-header {
     flex-direction: column;
     align-items: flex-start;
   }
 
-  main,
-  .app-shell {
-    padding: 1.5rem 1rem 3rem;
+  .header-actions {
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
   }
 }


### PR DESCRIPTION
## Резюме
- назначил режим "Сохранение в папку" режимом по умолчанию в настройках и в интерфейсе
- переработал шапку и блоки управления, добавил обновлённые подписи и бейджи
- полностью обновил тёмную тему интерфейса в стиле второго проекта (градиенты, сегменты, таблицы)

## Тесты
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d555ea27d4832aa1ac75f35a794a82